### PR TITLE
Fixed: error: unnecessary trailing semicolon

### DIFF
--- a/src/libstd/sys/vxworks/process/process_common.rs
+++ b/src/libstd/sys/vxworks/process/process_common.rs
@@ -155,7 +155,7 @@ impl Command {
         _f: Box<dyn FnMut() -> io::Result<()> + Send + Sync>,
     ) {
         // Fork() is not supported in vxWorks so no way to run the closure in the new procecss.
-        unimplemented!();;
+        unimplemented!();
     }
 
     pub fn stdin(&mut self, stdin: Stdio) {


### PR DESCRIPTION
The latest bootstrap cargo (2019-08-13) caught a hitherto unnoticed issue:

> error: unnecessary trailing semicolon
>    --> src/libstd/sys/vxworks/process/process_common.rs:158:26
>     |
> 158 |         unimplemented!();;
>     |                          ^ help: remove this semicolon
>     |
>     = note: `-D redundant-semicolon` implied by `-D warnings`
> 
> error: unreachable statement
>    --> src/libstd/sys/vxworks/process/process_common.rs:158:26
>     |
> 158 |         unimplemented!();;
>     |                          ^
>     |
>     = note: `-D unreachable-code` implied by `-D warnings`
> 
> error: aborting due to 2 previous errors
> 
> error: Could not compile `std`.
>  