### PR TITLE
Skip socket timeout tests on VxWorks

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1597,7 +1597,8 @@ mod tests {
 
     // FIXME: re-enabled openbsd tests once their socket timeout code
     //        no longer has rounding errors.
-    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd"), ignore)]
+    // VxWorks ignores SO_SNDTIMEO.
+    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd", target_os = "vxworks"), ignore)]
     #[cfg_attr(target_env = "sgx", ignore)] // FIXME: https://github.com/fortanix/rust-sgx/issues/31
     #[test]
     fn timeouts() {

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -1026,7 +1026,8 @@ mod tests {
 
     // FIXME: re-enabled openbsd/netbsd tests once their socket timeout code
     //        no longer has rounding errors.
-    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd"), ignore)]
+    // VxWorks ignores SO_SNDTIMEO.
+    #[cfg_attr(any(target_os = "netbsd", target_os = "openbsd", target_os = "vxworks"), ignore)]
     #[test]
     fn timeouts() {
         let addr = next_test_ip4();


### PR DESCRIPTION
VxWorks ignores the SO_SNDTIMEO socket option (this is long-standing behavior), so skip the following tests:

net::tcp::tests::timeouts
net::udp::tests::timeouts