### PR TITLE
do nothing in set_name()

### DIFF
--- a/src/libstd/sys/vxworks/thread.rs
+++ b/src/libstd/sys/vxworks/thread.rs
@@ -77,7 +77,7 @@ impl Thread {
     }
 
     pub fn set_name(_name: &CStr) {
-        assert!(false, "FIXME: set_name");
+        // VxWorks does not provide a way to set the task name except at creation time
     }
 
     pub fn sleep(dur: Duration) {


### PR DESCRIPTION
VxWorks doesn't support set thread's name after it has created, so make this function do nothing.

r? @n-salim 

@n-salim 
I am creating this PR again branch master_003 is because I want to create a seperate PR to upstream the code later. If I merge the code into branch master then the code would be part of last PR. I hope the PR for upstream this code would be faster in this way.