### PR TITLE
rust stat should call libc stat

### DIFF
--- a/src/libstd/sys/vxworks/fs.rs
+++ b/src/libstd/sys/vxworks/fs.rs
@@ -529,7 +529,7 @@ pub fn stat(p: &Path) -> io::Result<FileAttr> {
     let p = cstr(p)?;
     let mut stat: stat64 = unsafe { mem::zeroed() };
     cvt(unsafe {
-        libc::lstat(p.as_ptr(), &mut stat as *mut _ as *mut _)
+        libc::stat(p.as_ptr(), &mut stat as *mut _ as *mut _)
     })?;
     Ok(FileAttr { stat })
 }


### PR DESCRIPTION
This change makes two test cases pass:
test fs::tests::create_dir_all_with_junctions ... ok
test fs::tests::symlinks_work ... ok


r? @n-salim 