### PR TITLE
pass the captured environment variables to rtpSpawn

### DIFF
--- a/src/libstd/sys/vxworks/os.rs
+++ b/src/libstd/sys/vxworks/os.rs
@@ -11,14 +11,12 @@ use crate::path::{self, PathBuf, Path};
 use crate::ptr;
 use crate::slice;
 use crate::str;
-use crate::sys_common::mutex::Mutex;
+use crate::sys_common::mutex::{Mutex, MutexGuard};
 use crate::sys::cvt;
 /*use sys::fd; this one is probably important */
 use crate::vec;
 
 const TMPBUF_SZ: usize = 128;
-static ENV_LOCK: Mutex = Mutex::new();
-
 
 // This is a terrible fix
 use crate::sys::os_str::Buf;
@@ -200,11 +198,18 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     &mut environ
 }
 
+pub unsafe fn env_lock() -> MutexGuard<'static> {
+    // We never call `ENV_LOCK.init()`, so it is UB to attempt to
+    // acquire this mutex reentrantly!
+    static ENV_LOCK: Mutex = Mutex::new();
+    ENV_LOCK.lock()
+}
+
 /// Returns a vector of (variable, value) byte-vector pairs for all the
 /// environment variables of the current process.
 pub fn env() -> Env {
     unsafe {
-        let _guard = ENV_LOCK.lock();
+        let _guard = env_lock();
         let mut environ = *environ();
         if environ == ptr::null() {
             panic!("os::env() failure getting env string from OS: {}",
@@ -244,7 +249,7 @@ pub fn getenv(k: &OsStr) -> io::Result<Option<OsString>> {
     // always None as well
     let k = CString::new(k.as_bytes())?;
     unsafe {
-        let _guard = ENV_LOCK.lock();
+        let _guard = env_lock();
         let s = libc::getenv(k.as_ptr()) as *const libc::c_char;
         let ret = if s.is_null() {
             None
@@ -260,7 +265,7 @@ pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
     let v = CString::new(v.as_bytes())?;
 
     unsafe {
-        let _guard = ENV_LOCK.lock();
+        let _guard = env_lock();
         cvt(libc::setenv(k.as_ptr(), v.as_ptr(), 1)).map(|_| ())
     }
 }
@@ -269,7 +274,7 @@ pub fn unsetenv(n: &OsStr) -> io::Result<()> {
     let nbuf = CString::new(n.as_bytes())?;
 
     unsafe {
-        let _guard = ENV_LOCK.lock();
+        let _guard = env_lock();
         cvt(libc::unsetenv(nbuf.as_ptr())).map(|_| ())
     }
 }
@@ -287,7 +292,8 @@ pub fn temp_dir() -> PathBuf {
 }
 
 pub fn home_dir() -> Option<PathBuf> {
-    None
+    crate::env::var_os("HOME").or_else(|| None
+    ).map(PathBuf::from)
 }
 
 pub fn exit(code: i32) -> ! {

--- a/src/libstd/sys/vxworks/process/process_vxworks.rs
+++ b/src/libstd/sys/vxworks/process/process_vxworks.rs
@@ -55,13 +55,17 @@ impl Command {
 
             let c_envp = envp.as_ref().map(|c| c.as_ptr())
                 .unwrap_or_else(|| *sys::os::environ() as *const _);
-            
+            let stack_size = thread::min_stack();
+
+            // ensure that access to the environment is synchronized
+            let _lock = sys::os::env_lock();
+
             let ret = libc::rtpSpawn(
                 self.get_argv()[0],                   // executing program
                 self.get_argv().as_ptr() as *mut *const c_char, // argv
                 c_envp as *mut *const c_char,
                 100 as c_int,                         // initial priority
-                thread::min_stack(),                  // initial stack size.
+                stack_size,                           // initial stack size.
                 0,                                    // options
                 0                                     // task options
             );


### PR DESCRIPTION
capture_env() would capture all environment variables set before invoking a RTP process, I didn't realize it is different to what can get from sys::os::environ() when I removed it.

The reason I removed capture_env() beofore is I found the "envp" returned by it would be released when rtpSpawn() still need to use it.

Now I find out using as_ref() would make it keep alive.

This is to fix the issue found with test case test-panic-abort.rs which is reported in V7LIBC-1054.

r? @n-salim 
cc @UmeshKalappa 