### PR TITLE
add ExitStatusExt into prelude

### DIFF
--- a/src/libstd/sys/vxworks/ext/mod.rs
+++ b/src/libstd/sys/vxworks/ext/mod.rs
@@ -18,4 +18,7 @@ pub mod prelude {
     #[doc(no_inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+    #[doc(no_inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::process::ExitStatusExt;
 }


### PR DESCRIPTION
This is to fix V7LIBC-1069.
The traits of ExitStatusExt was not included in prelude which result the test case simd-target-feature-mixup.rs can't pass building.

r? @n-salim 
cc @UmeshKalappa 