### PR TITLE
Vxworks updates

### DIFF
--- a/library/std/src/sys/unix/os/tests.rs
+++ b/library/std/src/sys/unix/os/tests.rs
@@ -1,12 +1,14 @@
 use super::*;
 
 #[test]
+#[cfg(not(target_os = "vxworks"))]
 fn test_glibc_version() {
     // This mostly just tests that the weak linkage doesn't panic wildly...
     glibc_version();
 }
 
 #[test]
+#[cfg(not(target_os = "vxworks"))]
 fn test_parse_glibc_version() {
     let cases = [
         ("0.0", Some((0, 0))),

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -50,7 +50,7 @@ cfg_if::cfg_if! {
             raw[bit / 8] |= 1 << (bit % 8);
             return 0;
         }
-    } else if #[cfg(not(target_os = "vxworks"))] {
+    } else {
         pub use libc::{sigemptyset, sigaddset};
     }
 }


### PR DESCRIPTION
VxWorks supports some, but not all, of what Rust expects of a "UNIX" system.

Firstly, UNIX systems seem to need glibc, which VxWorks does not provide.
Secondly, older VxWorks seems to not have had `sigemptyset` or `sigaddset`.

This PR rectifies both of those issues by changing some `cfg` attributes.